### PR TITLE
EWO-1362: Update Drupal core-dev to 11.3.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "drupal/coder": "^8.3",
-        "drupal/core-dev": "10.6.10",
+        "drupal/core-dev": "11.3.11",
         "phpmd/phpmd": "^2.9",
         "drupal/entity_browser": "^2.13",
         "phpro/grumphp": "^2.12"


### PR DESCRIPTION
Updates the unity-dev-modules from drupal/core-dev 10.6.10 to 11.3.11 for the new 3.0 branch.